### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Disable dependabot updates…
+    open-pull-requests-limit: 0
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Disable dependabot updates…
+    open-pull-requests-limit: 0


### PR DESCRIPTION
# Problem

We have a ton of dependabot PR notifications in the C5 org that can drown out other notifications.

# Solution

Turn off Dependabot for repositories that have not had updates in a while.

# Further steps

We could potentially archive this or other repos, or mark them as not actively maintained to let folks know we aren't keeping things up to date.